### PR TITLE
Fix broken translation key

### DIFF
--- a/src/main/resources/data/skywars/lang/en_us.json
+++ b/src/main/resources/data/skywars/lang/en_us.json
@@ -1,5 +1,5 @@
 {
-  "game.skywars.skywars": "SkyWars",
+  "gameType.skywars.skywars": "SkyWars",
 
   "text.skywars.select_kit": "Select Your Kit",
   "text.skywars.selected": "Selected",


### PR DESCRIPTION
`game.skywars.skywars` is no longer correct.
This pull request changes it to `gameType.skywars.skywars`.