### PR TITLE
Allow players to shoot and feel pain again >:)

### DIFF
--- a/src/main/java/us/potatoboy/skywars/game/SkyWarsActive.java
+++ b/src/main/java/us/potatoboy/skywars/game/SkyWarsActive.java
@@ -210,7 +210,7 @@ public class SkyWarsActive {
             this.statistics.forPlayer(player).increment(StatisticKeys.DAMAGE_TAKEN, amount);
         }
 
-        return EventResult.DENY;
+        return EventResult.PASS;
     }
 
     private EventResult onPlayerDeath(ServerPlayerEntity player, DamageSource source) {
@@ -271,7 +271,7 @@ public class SkyWarsActive {
     private EventResult onArrowFire(ServerPlayerEntity player, ItemStack itemStack, ArrowItem arrowItem, int i, PersistentProjectileEntity persistentProjectileEntity) {
         this.statistics.forPlayer(player).increment(SkywarsStatistics.ARROWS_SHOT, 1);
 
-        return EventResult.DENY;
+        return EventResult.PASS;
     }
 
     private Text getDeathMessage(ServerPlayerEntity player, DamageSource source) {


### PR DESCRIPTION
There is no place for "Peace and Love ☮️" *-hugman* in Skywars, This is a war, of the skys!

With this change the non lethal training weapons, non firing bows and childproof void of yesteryear are replaced with their lethal counterparts fit for skywars!